### PR TITLE
Update routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,6 @@ Rails.application.routes.draw do
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
   curation_concerns_basic_routes
-  curation_concerns_embargo_management
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
Remove line:

curation_concerns_embargo_management

Due to future deprecation via sidekiq log:
DEPRECATION WARNING: #curation_concerns_embargo_management is deprecated and has no effect. It will be removed in Hyrax 3.0. (called from block in <top (required)> at /var/druw/config/routes.rb:28)