### PR TITLE
Add hyrax.en.yml.kate and regenerated hyrax.en.yml

### DIFF
--- a/config/locales/hyrax.en.yml.kate
+++ b/config/locales/hyrax.en.yml.kate
@@ -3,7 +3,7 @@ en:
     search:
       fields:
         facet:
-          based_near_label_sim: Location
+          based_near_sim: Location
           creator_sim: Creator
           file_format_sim: Format
           generic_type_sim: Type
@@ -23,9 +23,8 @@ en:
           identifier_tesim: Identifier
           keyword_tesim: Keyword
           language_tesim: Language
-          license_tesim: License
           publisher_tesim: Publisher
-          rights_statement_tesim: Rights Statement
+          rights_tesim: Rights
           subject_tesim: Subject
         show:
           based_near_tesim: Location
@@ -39,26 +38,41 @@ en:
           identifier_tesim: Identifier
           keyword_tesim: Keyword
           language_tesim: Language
-          license_tesim: License
           publisher_tesim: Publisher
-          rights_statement_tesim: Rights Statement
+          rights_tesim: Rights
           subject_tesim: Subject
           title_tesim: Title
   hyrax:
     product_name:           "DRUW"
-    product_twitter_handle: "@UWLibraries"
-    institution_name:       "UW"
-    institution_name_full:  "University of Washington Libraries"
+    product_long_name:      "Data Repository at the University of Washington"
+    product_twitter_handle: "@HydraSphere"
+    institution_name:       "Institution"
+    institution_name_full:  "The Institution Name"
     account_name:           "My Institution Account Id"
-    dashboard:
-      breadcrumbs:
-        admin:              "My Dashboard"
-      my:
-        works: "My Works"
     directory:
       suffix:               "@example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
-      service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
-    share_button:           "Deposit Your Work"
 
+
+    search:
+      button:
+        text: "Search"
+
+
+    nav_menu:
+      home: "Home"
+      browse: "Browse"
+      deposit: "Deposit"
+      help: "Help"
+         
+ 
+    statics:
+      about: "About"
+      collection_policy: "Collection Policy"
+      faq: "Frequently Asked Questions"
+      formats: "Recommended File Formats"
+      help: "Help"
+      protected_info: "Protected Information Policy"
+      terms_of_deposit: "Terms of Deposit"
+      terms_of_use: "Terms of Use"
+      withdrawal: "Withdrawal Policy"


### PR DESCRIPTION
Update of hyrax gem regenerates hyrax.en.yml and does not seem to include anything not in the community repo file [hyrax.en.yml](https://github.com/samvera/hyrax/blob/v2.0.0.rc2/config/locales/hyrax.en.yml)

The shorter file will result in page title errors in the browser tabs and hover over text for the static page links.