### PR TITLE
Uncommented the product_twitter_handle parameter to fix the issue of …

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -56,4 +56,4 @@ en:
     institution_name: University of Washington
     institution_name_full: University of Washington Libraries
     product_name: Data Repository at UW
-    #product_twitter_handle: "@uwlibraries"
+    product_twitter_handle: "@uwlibraries"


### PR DESCRIPTION
…broken headers.


We need to uncomment the product_twitter_handle parameter in order to fix some broken HTML in production.